### PR TITLE
increase CSS input widths to 218px

### DIFF
--- a/src/Components/MainContent/style.scss
+++ b/src/Components/MainContent/style.scss
@@ -148,7 +148,7 @@
       }
 
       .input-wrapper {
-        flex: 0 0 195px;
+        flex: 0 0 218px;
 
         input:not([type="checkbox"]),
         select {
@@ -170,7 +170,7 @@
 
       label {
         flex: 1;
-        flex: 0 0 195px;
+        flex: 0 0 218px;
       }
     }
 


### PR DESCRIPTION
- allows 'Rev' to be seen when setting to 3d-mode reversed
